### PR TITLE
Fixed all-assets being treated as a real chunk in doesChunkBelongToHML

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,10 +99,13 @@ class PreloadPlugin {
         }
 
         const publicPath = compilation.outputOptions.publicPath || '';
-
-        // Only handle the chunk import by the htmlWebpackPlugin
-        extractedChunks = extractedChunks.filter(chunk => doesChunkBelongToHTML(
-          chunk, Object.values(htmlPluginData.assets.chunks), {}));
+        
+        // only handle the chunks associated to this htmlWebpackPlugin instance, in case of multiple html plugin outputs
+        // allow `all-assets` mode to skip, as assets are just files to be filtered by black/whitelist, not real chunks
+        if (options.include !== 'all-assets') {
+          extractedChunks = extractedChunks.filter(chunk => doesChunkBelongToHTML(
+            chunk, Object.values(htmlPluginData.assets.chunks), {}));
+        }
 
         flatten(extractedChunks.map(chunk => chunk.files))
         .filter(entry => {


### PR DESCRIPTION
It should not be attempted to filtered as if it were a real chunk, they are just files to be black/whitelisted in config